### PR TITLE
pkg/phases: set runtime config for k8s 1.16

### DIFF
--- a/pkg/phases/kubeadm.go
+++ b/pkg/phases/kubeadm.go
@@ -1,6 +1,7 @@
 package phases
 
 import (
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -38,6 +39,18 @@ func NewClusterConfig(cfg *platform.Platform) api.ClusterConfiguration {
 		"oidc-ca-file":        "/etc/ssl/certs/openid-ca.pem",
 		"oidc-username-claim": "email",
 		"oidc-groups-claim":   "groups",
+	}
+	if strings.HasPrefix(cluster.APIVersion, "1.16") {
+		runtimeConfigs := []string{
+			"apps/v1beta1=true",
+			"apps/v1beta2=true",
+			"extensions/v1beta1/daemonsets=true",
+			"extensions/v1beta1/deployments=true",
+			"extensions/v1beta1/replicasets=true",
+			"extensions/v1beta1/networkpolicies=true",
+			"extensions/v1beta1/podsecuritypolicies=true",
+		}
+		cluster.APIServer.ExtraArgs["runtime-config"] = strings.Join(runtimeConfigs, ",")
 	}
 	return cluster
 }

--- a/test/kind.config.yaml
+++ b/test/kind.config.yaml
@@ -1,5 +1,15 @@
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "runtime-config": "apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+
 networking:
   disableDefaultCNI: true
 


### PR DESCRIPTION
k8s version 1.16 and later do not enable apps/v1beta1 and apps/v1beta2
by default. That causes some of the dependencies broken like pgo.

While waiting for those dependencies upgraded, we can make a workaround
by enable those features through runtime config.

Fixes #31