### PR TITLE
Add NodeLocal DNS cache

### DIFF
--- a/manifests/node-local-dns.yml
+++ b/manifests/node-local-dns.yml
@@ -1,0 +1,191 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-upstream
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNSUpstream"
+spec:
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+      targetPort: 53
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  Corefile: |
+    __PILLAR__DNS__DOMAIN__:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        health __PILLAR__LOCAL__DNS__:8080
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . __PILLAR__UPSTREAM__SERVERS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: node-local-dns
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      hostNetwork: true
+      dnsPolicy: Default # Don't use cluster DNS.
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      containers:
+        - name: node-cache
+          image: k8s.gcr.io/k8s-dns-node-cache:1.15.7
+          resources:
+            requests:
+              cpu: 25m
+              memory: 5Mi
+          args:
+            [
+              "-localip",
+              "__PILLAR__LOCAL__DNS__,__PILLAR__DNS__SERVER__",
+              "-conf",
+              "/etc/Corefile",
+              "-upstreamsvc",
+              "kube-dns-upstream",
+            ]
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+            - containerPort: 9253
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              host: __PILLAR__LOCAL__DNS__
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - name: config-volume
+              mountPath: /etc/coredns
+            - name: kube-dns-config
+              mountPath: /etc/kube-dns
+      volumes:
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        - name: kube-dns-config
+          configMap:
+            name: kube-dns
+            optional: true
+        - name: config-volume
+          configMap:
+            name: node-local-dns
+            items:
+              - key: Corefile
+                path: Corefile.base

--- a/pkg/phases/base/install.go
+++ b/pkg/phases/base/install.go
@@ -20,6 +20,12 @@ func Install(platform *platform.Platform) error {
 		log.Errorf("Error deploying tiller: %s\n", err)
 	}
 
+	if platform.NodeLocalDNS == nil || !platform.NodeLocalDNS.Disabled {
+		if err := platform.ApplySpecs("", "node-local-dns.yml"); err != nil {
+			log.Errorf("Error deploying node-local-dns: %s\n", err)
+		}
+	}
+
 	if platform.CertManager == nil || !platform.CertManager.Disabled {
 		log.Infof("Installing CertMananager")
 		if err := platform.ApplySpecs("", "cert-manager-crd.yml"); err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -39,6 +39,7 @@ type PlatformConfig struct {
 	NamespaceConfigurator *Enabled          `yaml:"namespaceConfigurator,omitempty"`
 	NFS                   *NFS              `yaml:"nfs,omitempty"`
 	Nodes                 map[string]VM     `yaml:"workers,omitempty"`
+	NodeLocalDNS          *Enabled          `yaml:"nodeLocalDNS,omitempty"`
 	NSX                   *NSX              `yaml:"nsx,omitempty"`
 	OPA                   *OPA              `yaml:"opa,omitempty"`
 	PGO                   *PostgresOperator `yaml:"pgo,omitempty"`

--- a/test/common.yml
+++ b/test/common.yml
@@ -27,6 +27,7 @@ calico:
   ipip: Never
   vxlan: Never
   version: v3.8.2
+nodeLocalDNS:
 monitoring:
   version: dfb626837f04756ed5a8805845f51ebd29d342ec
 pgo:


### PR DESCRIPTION
Deploy NodeLocal DNSCache to improve cluster DNS performance.

This runs a DNS caching agent as a `DaemonSet` in each node.

Pods running in a node will first reach the local agent and only after in case of a cache miss reach out the DNS server deployed in the cluster.

In our case, we run CoreDNS deployed via kubeadm.

Reference:

https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/