### PR TITLE
Fix NodeLocalDNS

### DIFF
--- a/manifests/node-local-dns.yml
+++ b/manifests/node-local-dns.yml
@@ -54,54 +54,54 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
-    __PILLAR__DNS__DOMAIN__:53 {
+    {{ .nodeLocalDNS.dnsDomain }}:53 {
         errors
         cache {
-                success 9984 30
-                denial 9984 5
+            success 9984 30
+            denial 9984 5
         }
         reload
         loop
-        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        bind {{ .nodeLocalDNS.localDNS }} {{ .nodeLocalDNS.dnsServer }}
         forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
+            force_tcp
         }
         prometheus :9253
-        health __PILLAR__LOCAL__DNS__:8080
-        }
+        health {{ .nodeLocalDNS.localDNS }}:8080
+    }
     in-addr.arpa:53 {
         errors
         cache 30
         reload
         loop
-        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        bind {{ .nodeLocalDNS.localDNS }} {{ .nodeLocalDNS.dnsServer }}
         forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
+            force_tcp
         }
         prometheus :9253
-        }
+    }
     ip6.arpa:53 {
         errors
         cache 30
         reload
         loop
-        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        bind {{ .nodeLocalDNS.localDNS }} {{ .nodeLocalDNS.dnsServer }}
         forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
+            force_tcp
         }
         prometheus :9253
-        }
+    }
     .:53 {
         errors
         cache 30
         reload
         loop
-        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        bind {{ .nodeLocalDNS.localDNS }} {{ .nodeLocalDNS.dnsServer }}
         forward . __PILLAR__UPSTREAM__SERVERS__ {
-                force_tcp
+            force_tcp
         }
         prometheus :9253
-        }
+    }
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -141,7 +141,7 @@ spec:
           args:
             [
               "-localip",
-              "__PILLAR__LOCAL__DNS__,__PILLAR__DNS__SERVER__",
+              "{{ .nodeLocalDNS.localDNS }},{{ .nodeLocalDNS.dnsServer }}",
               "-conf",
               "/etc/Corefile",
               "-upstreamsvc",
@@ -161,7 +161,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              host: __PILLAR__LOCAL__DNS__
+              host: "{{ .nodeLocalDNS.localDNS }}"
               path: /health
               port: 8080
             initialDelaySeconds: 60

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -39,7 +39,7 @@ type PlatformConfig struct {
 	NamespaceConfigurator *Enabled          `yaml:"namespaceConfigurator,omitempty"`
 	NFS                   *NFS              `yaml:"nfs,omitempty"`
 	Nodes                 map[string]VM     `yaml:"workers,omitempty"`
-	NodeLocalDNS          *Enabled          `yaml:"nodeLocalDNS,omitempty"`
+	NodeLocalDNS          NodeLocalDNS      `yaml:"nodeLocalDNS,omitempty"`
 	NSX                   *NSX              `yaml:"nsx,omitempty"`
 	OPA                   *OPA              `yaml:"opa,omitempty"`
 	PGO                   *PostgresOperator `yaml:"pgo,omitempty"`
@@ -57,8 +57,8 @@ type PlatformConfig struct {
 	PlatformOperator      *Enabled          `yaml:"platformOperator,omitempty"`
 	Nginx                 *Enabled          `yaml:"nginx,omitempty"`
 	Minio                 *Enabled          `yaml:"minio,omitempty"`
-	FluentdOperator 	  *FluentdOperator  `yaml:"fluentd-operator,omitempty"`
-	ECK 				  *ECK 				`yaml:"eck,omitempty"`
+	FluentdOperator       *FluentdOperator  `yaml:"fluentd-operator,omitempty"`
+	ECK                   *ECK              `yaml:"eck,omitempty"`
 }
 
 type Enabled struct {
@@ -162,22 +162,22 @@ type DB struct {
 }
 
 type PostgresOperator struct {
-	Disabled bool   `yaml:"disabled,omitempty"`
-	Version  string `yaml:"version,omitempty"`
-	PrimaryStorage string `yaml:"primaryStorage,omitempty"`
-	XlogStorage string `yaml:"xlogStorage,omitempty"`
-	BackupStorage string `yaml:"backupStorage,omitempty"`
-	ReplicaStorage string `yaml:"replicaStorage,omitempty"`
-	BackrestStorage string `yaml:"backrestStorage,omitempty"`
-	Storage map[string]PostgresOperatorStorage `yaml:"storage,omitempty"`
+	Disabled        bool                               `yaml:"disabled,omitempty"`
+	Version         string                             `yaml:"version,omitempty"`
+	PrimaryStorage  string                             `yaml:"primaryStorage,omitempty"`
+	XlogStorage     string                             `yaml:"xlogStorage,omitempty"`
+	BackupStorage   string                             `yaml:"backupStorage,omitempty"`
+	ReplicaStorage  string                             `yaml:"replicaStorage,omitempty"`
+	BackrestStorage string                             `yaml:"backrestStorage,omitempty"`
+	Storage         map[string]PostgresOperatorStorage `yaml:"storage,omitempty"`
 }
 
 type PostgresOperatorStorage struct {
-	AccessMode string `yaml:"AccessMode,omitempty"`
-	Size string `yaml:"Size,omitempty"`
-	StorageType string `yaml:"StorageType,omitempty"`
+	AccessMode   string `yaml:"AccessMode,omitempty"`
+	Size         string `yaml:"Size,omitempty"`
+	StorageType  string `yaml:"StorageType,omitempty"`
 	StorageClass string `yaml:"StorageClass,omitempty"`
-	Fsgroup string `yaml:"Fsgroup,omitempty"`
+	Fsgroup      string `yaml:"Fsgroup,omitempty"`
 }
 
 type Smtp struct {
@@ -338,14 +338,21 @@ type CA struct {
 }
 
 type FluentdOperator struct {
-	Disabled      bool                     `yaml:"disabled,omitempty"`
-	Version       string                   `yaml:"version,omitempty"`
-	ImageRepo	  string				   `yaml:"repository,omitempty"`
+	Disabled  bool   `yaml:"disabled,omitempty"`
+	Version   string `yaml:"version,omitempty"`
+	ImageRepo string `yaml:"repository,omitempty"`
 }
 
 type ECK struct {
-	Disabled      bool                     `yaml:"disabled,omitempty"`
-	Version       string                   `yaml:"version,omitempty"`
+	Disabled bool   `yaml:"disabled,omitempty"`
+	Version  string `yaml:"version,omitempty"`
+}
+
+type NodeLocalDNS struct {
+	Disabled  bool   `yaml:"disabled,omitempty"`
+	DNSServer string `yaml:"dnsServer,omitempty"`
+	LocalDNS  string `yaml:"localDNS,omitempty"`
+	DNSDomain string `yaml:"dnsDomain,omitempty"`
 }
 
 func (p PlatformConfig) GetImagePath(image string) string {

--- a/test/common.yml
+++ b/test/common.yml
@@ -28,6 +28,7 @@ calico:
   vxlan: Never
   version: v3.8.2
 nodeLocalDNS:
+  disabled: false
 monitoring:
   version: dfb626837f04756ed5a8805845f51ebd29d342ec
 pgo:


### PR DESCRIPTION
This PR aims to fix NodeLocalDNS.

It is still not tested.

I need to verify how the following values:

- `__PILLAR__CLUSTER__DNS__`
- `__PILLAR__UPSTREAM__SERVERS__`

are changed.

According to the documentation

> The following variables will be set by the node-cache images - k8s.gcr.io/k8s-dns-node-cache:1.15.6 or later. The values will be determined by reading the kube-dns configMap for custom Upstream server configuration.
`__PILLAR__CLUSTER__DNS__` - Upstream server for in-cluster queries.
`__PILLAR__UPSTREAM__SERVERS__` - Upstream servers for external queries.

But still not clear to me how.