### PR TITLE
Bump registry-credentials version to 1.10.flanksource.2

### DIFF
--- a/test/common.yaml
+++ b/test/common.yaml
@@ -202,7 +202,7 @@ vault:
   consul:
     bucket: "consul-backups"
 registryCredentials:
-  version: "v1.10.flanksource.1"
+  version: "v1.10.flanksource.2"
   namespace: "registry-credentials"
   aws:
     enabled: true


### PR DESCRIPTION
Fixes #263 with this commit:

https://github.com/flanksource/registry-creds/commit/cfe5cd0aaaa3cdf85edd70f7f6800d4fcb7d4beb